### PR TITLE
Rewrite Entry class to use private functions instead of private methods.

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -23,35 +23,35 @@ export class Entry<TArgs extends any[], TValue, TKey> {
   public unsubscribe?: () => any;
   public reportOrphan?: (entry: Entry<TArgs, TValue, TKey>) => any;
 
-  private parents = new Set<AnyEntry>();
-  private childValues = new Map<AnyEntry, any>();
+  public readonly parents = new Set<AnyEntry>();
+  public readonly childValues = new Map<AnyEntry, any>();
 
   // When this Entry has children that are dirty, this property becomes
   // a Set containing other Entry objects, borrowed from emptySetPool.
   // When the set becomes empty, it gets recycled back to emptySetPool.
-  private dirtyChildren: Set<AnyEntry> | null = null;
+  public dirtyChildren: Set<AnyEntry> | null = null;
 
-  private dirty = true;
-  private recomputing = false;
-  private value: TValue = UNKNOWN_VALUE;
+  public dirty = true;
+  public recomputing = false;
+  public value: TValue = UNKNOWN_VALUE;
 
   constructor(
     public readonly fn: (...args: TArgs) => TValue,
-    public args: Readonly<TArgs>,
+    public args: TArgs,
     public readonly key: TKey,
   ) {
     ++Entry.count;
   }
 
   public recompute(): TValue {
-    if (! this.rememberParent() && this.maybeReportOrphan()) {
+    if (! rememberParent(this) && maybeReportOrphan(this)) {
       // The recipient of the entry.reportOrphan callback decided to dispose
       // of this orphan entry by calling entry.dispose(), so we don't need to
       // (and should not) proceed with the recomputation.
       return void 0 as any;
     }
 
-    return this.recomputeIfDirty();
+    return recomputeIfDirty(this);
   }
 
   public isOrphan() {
@@ -62,16 +62,16 @@ export class Entry<TArgs extends any[], TValue, TKey> {
     if (this.dirty) return;
     this.dirty = true;
     this.value = UNKNOWN_VALUE;
-    this.reportDirty();
+    reportDirty(this);
     // We can go ahead and unsubscribe here, since any further dirty
     // notifications we receive will be redundant, and unsubscribing may
     // free up some resources, e.g. file watchers.
-    this.maybeUnsubscribe();
+    maybeUnsubscribe(this);
   }
 
   public dispose() {
-    this.forgetChildren().forEach(child => child.maybeReportOrphan());
-    this.maybeUnsubscribe();
+    forgetChildren(this).forEach(maybeReportOrphan);
+    maybeUnsubscribe(this);
 
     // Because this entry has been kicked out of the cache (in index.js),
     // we've lost the ability to find out if/when this entry becomes dirty,
@@ -86,256 +86,256 @@ export class Entry<TArgs extends any[], TValue, TKey> {
     // truly forgotten.
     this.parents.forEach(parent => {
       parent.setDirty();
-      parent.forgetChild(this);
+      forgetChild(parent, this);
+    });
+  }
+}
+
+function rememberParent(child: AnyEntry) {
+  const local = getLocal();
+  const parent = local.currentParentEntry;
+  if (parent) {
+    child.parents.add(parent);
+
+    if (! parent.childValues.has(child)) {
+      parent.childValues.set(child, UNKNOWN_VALUE);
+    }
+
+    if (mightBeDirty(child)) {
+      reportDirtyChild(parent, child);
+    } else {
+      reportCleanChild(parent, child);
+    }
+
+    return parent;
+  }
+}
+
+// This is the most important method of the Entry API, because it
+// determines whether the cached entry.value can be returned immediately,
+// or must be recomputed. The overall performance of the caching system
+// depends on the truth of the following observations: (1) this.dirty is
+// usually false, (2) this.dirtyChildren is usually null/empty, and thus
+// (3) this.value is usally returned very quickly, without recomputation.
+function recomputeIfDirty(entry: AnyEntry) {
+  if (entry.dirty) {
+    // If this Entry is explicitly dirty because someone called
+    // entry.setDirty(), recompute.
+    return reallyRecompute(entry);
+  }
+
+  if (mightBeDirty(entry)) {
+    // Get fresh values for any dirty children, and if those values
+    // disagree with this.childValues, mark this Entry explicitly dirty.
+    entry.dirtyChildren!.forEach(child => {
+      assert(entry.childValues.has(child));
+      try {
+        recomputeIfDirty(child);
+      } catch (e) {
+        entry.setDirty();
+      }
+    });
+
+    if (entry.dirty) {
+      // If this Entry has become explicitly dirty after comparing the fresh
+      // values of its dirty children against this.childValues, recompute.
+      return reallyRecompute(entry);
+    }
+  }
+
+  assert(entry.value !== UNKNOWN_VALUE);
+
+  return entry.value;
+}
+
+function reallyRecompute(entry: AnyEntry) {
+  assert(! entry.recomputing, "already recomputing");
+  entry.recomputing = true;
+
+  // Since this recomputation is likely to re-remember some of this
+  // entry's children, we forget our children here but do not call
+  // maybeReportOrphan until after the recomputation finishes.
+  const originalChildren = forgetChildren(entry);
+
+  const local = getLocal();
+  const parent = local.currentParentEntry;
+  local.currentParentEntry = entry;
+
+  let threw = true;
+  try {
+    entry.value = entry.fn.apply(null, entry.args);
+    threw = false;
+
+  } finally {
+    entry.recomputing = false;
+
+    assert(local.currentParentEntry === entry);
+    local.currentParentEntry = parent;
+
+    if (threw || ! maybeSubscribe(entry)) {
+      // Mark this Entry dirty if entry.fn threw or we failed to
+      // resubscribe. This is important because, if we have a subscribe
+      // function and it failed, then we're going to miss important
+      // notifications about the potential dirtiness of entry.value.
+      entry.setDirty();
+    } else {
+      // If we successfully recomputed entry.value and did not fail to
+      // (re)subscribe, then this Entry is no longer explicitly dirty.
+      setClean(entry);
+    }
+  }
+
+  // Now that we've had a chance to re-remember any children that were
+  // involved in the recomputation, we can safely report any orphan
+  // children that remain.
+  originalChildren.forEach(maybeReportOrphan);
+
+  return entry.value;
+}
+
+function mightBeDirty(entry: AnyEntry) {
+  return entry.dirty || !!(entry.dirtyChildren && entry.dirtyChildren.size);
+}
+
+function setClean(entry: AnyEntry) {
+  entry.dirty = false;
+
+  if (mightBeDirty(entry)) {
+    // This Entry may still have dirty children, in which case we can't
+    // let our parents know we're clean just yet.
+    return;
+  }
+
+  reportClean(entry);
+}
+
+function reportDirty(child: AnyEntry) {
+  child.parents.forEach(parent => reportDirtyChild(parent, child));
+}
+
+function reportClean(child: AnyEntry) {
+  child.parents.forEach(parent => reportCleanChild(parent, child));
+}
+
+// Let a parent Entry know that one of its children may be dirty.
+function reportDirtyChild(parent: AnyEntry, child: AnyEntry) {
+  // Must have called rememberParent(child) before calling
+  // reportDirtyChild(parent, child).
+  assert(parent.childValues.has(child));
+  assert(mightBeDirty(child));
+
+  if (! parent.dirtyChildren) {
+    parent.dirtyChildren = emptySetPool.pop() || new Set;
+
+  } else if (parent.dirtyChildren.has(child)) {
+    // If we already know this child is dirty, then we must have already
+    // informed our own parents that we are dirty, so we can terminate
+    // the recursion early.
+    return;
+  }
+
+  parent.dirtyChildren.add(child);
+  reportDirty(parent);
+}
+
+// Let a parent Entry know that one of its children is no longer dirty.
+function reportCleanChild(parent: AnyEntry, child: AnyEntry) {
+  // Must have called rememberChild(child) before calling
+  // reportCleanChild(parent, child).
+  assert(parent.childValues.has(child));
+  assert(! mightBeDirty(child));
+
+  const childValue = parent.childValues.get(child);
+  if (childValue === UNKNOWN_VALUE) {
+    parent.childValues.set(child, child.value);
+  } else if (childValue !== child.value) {
+    parent.setDirty();
+  }
+
+  removeDirtyChild(parent, child);
+
+  if (mightBeDirty(parent)) {
+    return;
+  }
+
+  reportClean(parent);
+}
+
+function removeDirtyChild(parent: AnyEntry, child: AnyEntry) {
+  const dc = parent.dirtyChildren;
+  if (dc) {
+    dc.delete(child);
+    if (dc.size === 0) {
+      if (emptySetPool.length < Entry.POOL_TARGET_SIZE) {
+        emptySetPool.push(dc);
+      }
+      parent.dirtyChildren = null;
+    }
+  }
+}
+
+// If the given entry has a reportOrphan method, and no remaining parents,
+// call entry.reportOrphan and return true iff it returns true. The
+// reportOrphan function should return true to indicate entry.dispose()
+// has been called, and the entry has been removed from any other caches
+// (see index.js for the only current example).
+function maybeReportOrphan(entry: AnyEntry) {
+  const report = entry.reportOrphan;
+  return typeof report === "function" &&
+    entry.parents.size === 0 &&
+    report(entry) === true;
+}
+
+// Removes all children from this entry and returns an array of the
+// removed children.
+function forgetChildren(parent: AnyEntry) {
+  let children = reusableEmptyArray;
+
+  if (parent.childValues.size > 0) {
+    children = [];
+    parent.childValues.forEach((value, child) => {
+      forgetChild(parent, child);
+      children.push(child);
     });
   }
 
-  private rememberParent() {
-    const local = getLocal();
-    const parent = local.currentParentEntry;
-    if (parent) {
-      this.parents.add(parent);
+  // After we forget all our children, this.dirtyChildren must be empty
+  // and therefore must have been reset to null.
+  assert(parent.dirtyChildren === null);
 
-      if (! parent.childValues.has(this)) {
-        parent.childValues.set(this, UNKNOWN_VALUE);
-      }
+  return children;
+}
 
-      if (this.mightBeDirty()) {
-        parent.reportDirtyChild(this);
-      } else {
-        parent.reportCleanChild(this);
-      }
+function forgetChild(parent: AnyEntry, child: AnyEntry) {
+  child.parents.delete(parent);
+  parent.childValues.delete(child);
+  removeDirtyChild(parent, child);
+}
 
-      return parent;
-    }
-  }
-
-  // This is the most important method of the Entry API, because it
-  // determines whether the cached entry.value can be returned immediately,
-  // or must be recomputed. The overall performance of the caching system
-  // depends on the truth of the following observations: (1) this.dirty is
-  // usually false, (2) this.dirtyChildren is usually null/empty, and thus
-  // (3) this.value is usally returned very quickly, without recomputation.
-  private recomputeIfDirty() {
-    if (this.dirty) {
-      // If this Entry is explicitly dirty because someone called
-      // entry.setDirty(), recompute.
-      return this.reallyRecompute();
-    }
-
-    if (this.mightBeDirty()) {
-      // Get fresh values for any dirty children, and if those values
-      // disagree with this.childValues, mark this Entry explicitly dirty.
-      this.dirtyChildren!.forEach(child => {
-        assert(this.childValues.has(child));
-        try {
-          child.recomputeIfDirty();
-        } catch (e) {
-          this.setDirty();
-        }
-      });
-
-      if (this.dirty) {
-        // If this Entry has become explicitly dirty after comparing the fresh
-        // values of its dirty children against this.childValues, recompute.
-        return this.reallyRecompute();
-      }
-    }
-
-    assert(this.value !== UNKNOWN_VALUE);
-
-    return this.value;
-  }
-
-  private reallyRecompute() {
-    assert(! this.recomputing, "already recomputing");
-    this.recomputing = true;
-
-    // Since this recomputation is likely to re-remember some of this
-    // entry's children, we forget our children here but do not call
-    // maybeReportOrphan until after the recomputation finishes.
-    const originalChildren = this.forgetChildren();
-
-    const local = getLocal();
-    const parent = local.currentParentEntry;
-    local.currentParentEntry = this;
-
-    let threw = true;
+function maybeSubscribe(entry: AnyEntry) {
+  if (typeof entry.subscribe === "function") {
     try {
-      this.value = this.fn.apply(null, this.args);
-      threw = false;
-
-    } finally {
-      this.recomputing = false;
-
-      assert(local.currentParentEntry === this);
-      local.currentParentEntry = parent;
-
-      if (threw || ! this.maybeSubscribe()) {
-        // Mark this Entry dirty if entry.fn threw or we failed to
-        // resubscribe. This is important because, if we have a subscribe
-        // function and it failed, then we're going to miss important
-        // notifications about the potential dirtiness of entry.value.
-        this.setDirty();
-      } else {
-        // If we successfully recomputed entry.value and did not fail to
-        // (re)subscribe, then this Entry is no longer explicitly dirty.
-        this.setClean();
-      }
-    }
-
-    // Now that we've had a chance to re-remember any children that were
-    // involved in the recomputation, we can safely report any orphan
-    // children that remain.
-    originalChildren.forEach(child => child.maybeReportOrphan());
-
-    return this.value;
-  }
-
-  private mightBeDirty() {
-    return this.dirty || !!(this.dirtyChildren && this.dirtyChildren.size);
-  }
-
-  private setClean() {
-    this.dirty = false;
-
-    if (this.mightBeDirty()) {
-      // This Entry may still have dirty children, in which case we can't
-      // let our parents know we're clean just yet.
-      return;
-    }
-
-    this.reportClean();
-  }
-
-  private reportDirty() {
-    this.parents.forEach(parent => parent.reportDirtyChild(this));
-  }
-
-  private reportClean() {
-    this.parents.forEach(parent => parent.reportCleanChild(this));
-  }
-
-  // Let a parent Entry know that one of its children may be dirty.
-  private reportDirtyChild(child: AnyEntry) {
-    // Must have called rememberParent(child) before calling
-    // reportDirtyChild(parent, child).
-    assert(this.childValues.has(child));
-    assert(child.mightBeDirty());
-
-    if (! this.dirtyChildren) {
-      this.dirtyChildren = emptySetPool.pop() || new Set;
-
-    } else if (this.dirtyChildren.has(child)) {
-      // If we already know this child is dirty, then we must have already
-      // informed our own parents that we are dirty, so we can terminate
-      // the recursion early.
-      return;
-    }
-
-    this.dirtyChildren.add(child);
-    this.reportDirty();
-  }
-
-  // Let a parent Entry know that one of its children is no longer dirty.
-  private reportCleanChild(child: AnyEntry) {
-    // Must have called rememberChild(child) before calling
-    // reportCleanChild(parent, child).
-    assert(this.childValues.has(child));
-    assert(! child.mightBeDirty());
-
-    const childValue = this.childValues.get(child);
-    if (childValue === UNKNOWN_VALUE) {
-      this.childValues.set(child, child.value);
-    } else if (childValue !== child.value) {
-      this.setDirty();
-    }
-
-    this.removeDirtyChild(child);
-
-    if (this.mightBeDirty()) {
-      return;
-    }
-
-    this.reportClean();
-  }
-
-  private removeDirtyChild(child: AnyEntry) {
-    const dc = this.dirtyChildren;
-    if (dc) {
-      dc.delete(child);
-      if (dc.size === 0) {
-        if (emptySetPool.length < Entry.POOL_TARGET_SIZE) {
-          emptySetPool.push(dc);
-        }
-        this.dirtyChildren = null;
-      }
+      maybeUnsubscribe(entry); // Prevent double subscriptions.
+      entry.unsubscribe = entry.subscribe.apply(null, entry.args);
+    } catch (e) {
+      // If this Entry has a subscribe function and it threw an exception
+      // (or an unsubscribe function it previously returned now throws),
+      // return false to indicate that we were not able to subscribe (or
+      // unsubscribe), and this Entry should remain dirty.
+      entry.setDirty();
+      return false;
     }
   }
 
-  // If the given entry has a reportOrphan method, and no remaining parents,
-  // call entry.reportOrphan and return true iff it returns true. The
-  // reportOrphan function should return true to indicate entry.dispose()
-  // has been called, and the entry has been removed from any other caches
-  // (see index.js for the only current example).
-  private maybeReportOrphan() {
-    const report = this.reportOrphan;
-    return typeof report === "function" &&
-      this.parents.size === 0 &&
-      report(this) === true;
-  }
+  // Returning true indicates either that there was no entry.subscribe
+  // function or that it succeeded.
+  return true;
+}
 
-  // Removes all children from this entry and returns an array of the
-  // removed children.
-  private forgetChildren() {
-    let children = reusableEmptyArray;
-
-    if (this.childValues.size > 0) {
-      children = [];
-      this.childValues.forEach((value, child) => {
-        this.forgetChild(child);
-        children.push(child);
-      });
-    }
-
-    // After we forget all our children, this.dirtyChildren must be empty
-    // and therefore must have been reset to null.
-    assert(this.dirtyChildren === null);
-
-    return children;
-  }
-
-  private forgetChild(child: AnyEntry) {
-    child.parents.delete(this);
-    this.childValues.delete(child);
-    this.removeDirtyChild(child);
-  }
-
-  private maybeSubscribe() {
-    if (typeof this.subscribe === "function") {
-      try {
-        this.maybeUnsubscribe(); // Prevent double subscriptions.
-        this.unsubscribe = this.subscribe.apply(null, this.args);
-      } catch (e) {
-        // If this Entry has a subscribe function and it threw an exception
-        // (or an unsubscribe function it previously returned now throws),
-        // return false to indicate that we were not able to subscribe (or
-        // unsubscribe), and this Entry should remain dirty.
-        this.setDirty();
-        return false;
-      }
-    }
-
-    // Returning true indicates either that there was no entry.subscribe
-    // function or that it succeeded.
-    return true;
-  }
-
-  private maybeUnsubscribe() {
-    const { unsubscribe } = this;
-    if (typeof unsubscribe === "function") {
-      this.unsubscribe = void 0;
-      unsubscribe();
-    }
+function maybeUnsubscribe(entry: AnyEntry) {
+  const { unsubscribe } = entry;
+  if (typeof unsubscribe === "function") {
+    entry.unsubscribe = void 0;
+    unsubscribe();
   }
 }


### PR DESCRIPTION
Because the function names can now be minified to single characters, this results in significant bundle size savings (17.5% minified, 5.7% after gzip) and a modest performance improvement.

Making all `Entry` properties public (so that they can be consumed by external functions) is not a problem because the entire `Entry` class is a private API of the `optimism` package.