### PR TITLE
Cache exceptions as well as ordinary values.

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -22,7 +22,14 @@ type Value<T> =
 
 function valueIs(a: Value<any>, b: Value<any>) {
   const len = a.length;
-  return len === b.length && a[len - 1] === b[len - 1];
+  return (
+    // Unknown values are not equal to each other.
+    len > 0 &&
+    // Both values must be ordinary (or both exceptional) to be equal.
+    len === b.length &&
+    // The underlying value or exception must be the same.
+    a[len - 1] === b[len - 1]
+  );
 }
 
 function valueGet<T>(value: Value<T>): T {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -73,13 +73,13 @@ export class Entry<TArgs extends any[], TValue> {
   }
 
   public recompute(): TValue {
+    assertNotRecomputing(this);
     if (! rememberParent(this) && maybeReportOrphan(this)) {
       // The recipient of the entry.reportOrphan callback decided to dispose
       // of this orphan entry by calling entry.dispose(), so we don't need to
       // (and should not) proceed with the recomputation.
       return void 0 as any;
     }
-
     return recomputeIfDirty(this);
   }
 
@@ -180,8 +180,12 @@ function recomputeSilently(entry: AnyEntry) {
   }
 }
 
-function reallyRecompute(entry: AnyEntry) {
+function assertNotRecomputing(entry: AnyEntry) {
   assert(! entry.recomputing, "already recomputing");
+}
+
+function reallyRecompute(entry: AnyEntry) {
+  assertNotRecomputing(entry);
 
   // Since this recomputation is likely to re-remember some of this
   // entry's children, we forget our children here but do not call

--- a/src/tests/exceptions.ts
+++ b/src/tests/exceptions.ts
@@ -35,4 +35,42 @@ describe("exceptions", function () {
     wrapper.dirty();
     assert.strictEqual(wrapper(), "already threw");
   });
+
+  it("should memoize a throwing fibonacci function", function () {
+    const fib = wrap((n: number) => {
+      if (n < 2) throw n;
+      try {
+        fib(n - 1);
+      } catch (minusOne) {
+        try {
+          fib(n - 2);
+        } catch (minusTwo) {
+          throw minusOne + minusTwo;
+        }
+      }
+      throw new Error("unreached");
+    });
+
+    function check(n: number, expected: number) {
+      try {
+        fib(n);
+        throw new Error("unreached");
+      } catch (result) {
+        assert.strictEqual(result, expected);
+      }
+    }
+
+    check(78, 8944394323791464);
+    check(68, 72723460248141);
+    check(58, 591286729879);
+    check(48, 4807526976);
+    fib.dirty(28);
+    check(38, 39088169);
+    check(28, 317811);
+    check(18, 2584);
+    check(8,  21);
+    fib.dirty(20);
+    check(78, 8944394323791464);
+    check(10, 55);
+  });
 });

--- a/src/tests/exceptions.ts
+++ b/src/tests/exceptions.ts
@@ -1,0 +1,38 @@
+import * as assert from "assert";
+import { wrap } from "..";
+
+describe("exceptions", function () {
+  it("should be cached", function () {
+    const error = new Error("expected");
+    let threw = false;
+    function throwOnce() {
+      if (!threw) {
+        threw = true;
+        throw error;
+      }
+      return "already threw";
+    }
+
+    const wrapper = wrap(throwOnce);
+
+    try {
+      wrapper();
+      throw new Error("unreached");
+    } catch (e) {
+      assert.strictEqual(e, error);
+    }
+
+    try {
+      wrapper();
+      throw new Error("unreached");
+    } catch (e) {
+      assert.strictEqual(e, error);
+    }
+
+    wrapper.dirty();
+    assert.strictEqual(wrapper(), "already threw");
+    assert.strictEqual(wrapper(), "already threw");
+    wrapper.dirty();
+    assert.strictEqual(wrapper(), "already threw");
+  });
+});

--- a/src/tests/main.ts
+++ b/src/tests/main.ts
@@ -2,4 +2,5 @@ import "./api";
 import "./cache";
 import "./key-trie";
 import "./context";
+import "./exceptions";
 import "./performance";


### PR DESCRIPTION
Previously, if a wrapped function threw an exception, no result would be cached, and the function would be recomputed the next time its wrapper was called, even if nothing upon which it depended had changed.

One of the goals of this library is to work equally well with `Promise` results as it does with ordinary results. Since a `Promise` can represent either an ordinary value or an exception, it seems important for the non-`Promise` behavior of this library to align with `Promise` behavior.

This means, most importantly, that we should be caching exceptions as well as ordinary results, to avoid doing unnecessary work just because the previous invocation of a cached function threw an exception.

If you call a cached function multiple times and get the same (`===`) rejected `Promise` object, the rejection values will be `===` to each other, because a `Promise` can have at most one rejection value. The same should be true for a cached function that throws an `Error` object (or any JavaScript value, for that matter): thrown values should be `===` to one another if nothing has changed, just as ordinary results are `===` to one another.

This new exception-caching behavior is definitely a minor breaking change, but you can reproduce the old semantics by calling `wrapper.dirty(...args)` when an exception is thrown:
```js
try {
  result = cachedWrapperFunction(a, b);
} catch (e) {
  cachedWrapperFunction.dirty(a, b);
  throw e;
}
```
Internally, unknown, ordinary, and exceptional values are represented as arrays: `[]`, `[value]`, and `[,exception]`, respectively.