### PR TITLE
Remove unsafe arms-length optimization in recomputeIfDirty.

### DIFF
--- a/src/tests/api.ts
+++ b/src/tests/api.ts
@@ -445,7 +445,7 @@ describe("optimism", function () {
     childBody = callParent;
     parentBody = () => "parent";
     child.dirty();
-    assert.strictEqual(child(), "child");
+    assert.strictEqual(child(), "parent");
     dep.dirty();
     assert.strictEqual(child(), "parent");
   });


### PR DESCRIPTION
In PR #29, I reluctantly decided to preserve an old optimization in `recomputeIfDirty` that would preemptively recompute `entry.dirtyChildren` before calling `reallyRecompute(entry)`, and if none of the `dirtyChildren`’s values changed, we would assume the parent did not really need to be recomputed.

The presence of this optimization required extra effort when implementing dependency functions that don't have a meaningful return value. Often one would have to return an incrementing counter from these functions, just to convince the caching system that the dirtiness of the function should matter to its callers. At some level I think I always knew this optimization was not worth the added complexity, but I didn’t want to admit it.

While testing `optimism@0.10.0` within Meteor, I noticed a situation where this counter trick was necessary, but some of the wrapped functions involved were also declared as `wrap(fn, { disposable: true })`. The `disposable` concept here is supposed to mean we don't care about the return values of these functions, which enables certain shortcuts.

However, in order to ensure nobody depends on the value of a disposable function, we force them to return `undefined`, which defeats the incrementing counter trick, thereby rendering the dirtiness of such functions mostly meaningless, which sometimes prevented their ancestor functions from being recomputed properly.

Now, I could have simply removed the `disposable: true` marker from these functions, but disposable functions are absolutely supposed to participate in dirty/clean notifications, so I consider it a serious bug that dirty disposable functions are ignored by the optimization in question.

Perhaps more importantly, I do not relish the thought of explaining this optimization to other engineers, since it has real consequences, and the symptoms of not following its rules were very hard to debug, even for the author of this code.