### PR TITLE
Re-export OptimisticDependencyFunction from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {
 // with only one argument, no makeCacheKey, no wrapped function to recompute,
 // and no result value. Useful for representing dependency leaves in the graph
 // of computation. Subscriptions are supported.
-export { dep } from "./dep";
+export { dep, OptimisticDependencyFunction } from "./dep";
 
 // Since the Cache uses a Map internally, any value or object reference can
 // be safely used as a key, though common types include object and string.


### PR DESCRIPTION
The `OptimisticDependencyFunction` type is used by Apollo Client, and isn't currently showing up in the auto-generated `./lib/index.d.ts` file. This PR re-exports it from `index.ts`, so TS includes it in `index.d.ts`.

Related: https://github.com/apollographql/apollo-client/pull/5357/commits/68195a930b51bcbbe9bf7bc79a6826f761ccdb25