### PR TITLE
Allow peeking cached values without recomputing them.

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -72,6 +72,12 @@ export class Entry<TArgs extends any[], TValue> {
     ++Entry.count;
   }
 
+  public peek(): TValue | undefined {
+    if (this.value.length === 1 && !mightBeDirty(this)) {
+      return this.value[0];
+    }
+  }
+
   // This is the most important method of the Entry API, because it
   // determines whether the cached this.value can be returned immediately,
   // or must be recomputed. The overall performance of the caching system

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,16 +136,16 @@ export function wrap<
   }
 
   optimistic.dirty = function () {
-    const child = lookup.apply(null, arguments as any);
-    if (child) {
-      child.setDirty();
+    const entry = lookup.apply(null, arguments as any);
+    if (entry) {
+      entry.setDirty();
     }
   };
 
   optimistic.peek = function () {
-    const child = lookup.apply(null, arguments as any);
-    if (child) {
-      return child.peek();
+    const entry = lookup.apply(null, arguments as any);
+    if (entry) {
+      return entry.peek();
     }
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export type OptimisticWrapperFunction<
   // The .dirty(...) method of an optimistic function takes exactly the
   // same parameter types as the original function.
   dirty: (...args: TKeyArgs) => void;
+  // Examine the current value without recomputing it.
+  peek: (...args: TKeyArgs) => TResult | undefined;
 };
 
 export type OptimisticWrapOptions<
@@ -126,11 +128,24 @@ export function wrap<
     return value;
   }
 
-  optimistic.dirty = function () {
+  function lookup() {
     const key = makeCacheKey.apply(null, keyArgs.apply(null, arguments as any));
-    const child = key !== void 0 && cache.get(key);
+    if (key !== void 0) {
+      return cache.get(key);
+    }
+  }
+
+  optimistic.dirty = function () {
+    const child = lookup.apply(null, arguments as any);
     if (child) {
       child.setDirty();
+    }
+  };
+
+  optimistic.peek = function () {
+    const child = lookup.apply(null, arguments as any);
+    if (child) {
+      return child.peek();
     }
   };
 

--- a/src/tests/api.ts
+++ b/src/tests/api.ts
@@ -548,4 +548,35 @@ describe("optimism", function () {
     assert.strictEqual(fib(18), 2584);
     assert.strictEqual(fib(8),  21);
   });
+
+  it("allows peeking the current value", function () {
+    const sumFirst = wrap(function (n: number): number {
+      return n < 1 ? 0 : n + sumFirst(n - 1);
+    });
+
+    assert.strictEqual(sumFirst.peek(3), void 0);
+    assert.strictEqual(sumFirst.peek(2), void 0);
+    assert.strictEqual(sumFirst.peek(1), void 0);
+    assert.strictEqual(sumFirst.peek(0), void 0);
+    assert.strictEqual(sumFirst(3), 6);
+    assert.strictEqual(sumFirst.peek(3), 6);
+    assert.strictEqual(sumFirst.peek(2), 3);
+    assert.strictEqual(sumFirst.peek(1), 1);
+    assert.strictEqual(sumFirst.peek(0), 0);
+
+    assert.strictEqual(sumFirst.peek(7), void 0);
+    assert.strictEqual(sumFirst(10), 55);
+    assert.strictEqual(sumFirst.peek(9), 55 - 10);
+    assert.strictEqual(sumFirst.peek(8), 55 - 10 - 9);
+    assert.strictEqual(sumFirst.peek(7), 55 - 10 - 9 - 8);
+
+    sumFirst.dirty(7);
+    // Everything from 7 and above is now unpeekable.
+    assert.strictEqual(sumFirst.peek(10), void 0);
+    assert.strictEqual(sumFirst.peek(9), void 0);
+    assert.strictEqual(sumFirst.peek(8), void 0);
+    assert.strictEqual(sumFirst.peek(7), void 0);
+    // Since 6 < 7, its value is still cached.
+    assert.strictEqual(sumFirst.peek(6), 6 * 7 / 2);
+  });
 });


### PR DESCRIPTION
Peeking cached values can be useful when you want to know if a given result is still the freshest/latest value, so you can (for example) avoid unnecessary processing that would likely just produce the same result again.

Like the `dirty` method, `peek` takes the `TKeyArgs` arguments type produced by `options.keyArgs`, if provided.