### PR TITLE
Support optimistic.forget to remove Entry objects from Cache.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ export type OptimisticWrapperFunction<
   dirty: (...args: TKeyArgs) => void;
   // Examine the current value without recomputing it.
   peek: (...args: TKeyArgs) => TResult | undefined;
+  // Remove the entry from the cache, dirtying any parent entries.
+  forget: (...args: TKeyArgs) => boolean;
 };
 
 export type OptimisticWrapOptions<
@@ -147,6 +149,11 @@ export function wrap<
     if (entry) {
       return entry.peek();
     }
+  };
+
+  optimistic.forget = function () {
+    const key = makeCacheKey.apply(null, arguments as any);
+    return key !== void 0 && cache.delete(key);
   };
 
   return optimistic as OptimisticWrapperFunction<TArgs, TResult, TKeyArgs>;

--- a/src/tests/api.ts
+++ b/src/tests/api.ts
@@ -579,4 +579,39 @@ describe("optimism", function () {
     // Since 6 < 7, its value is still cached.
     assert.strictEqual(sumFirst.peek(6), 6 * 7 / 2);
   });
+
+  it("allows forgetting entries", function () {
+    const ns: number[] = [];
+    const sumFirst = wrap(function (n: number): number {
+      ns.push(n);
+      return n < 1 ? 0 : n + sumFirst(n - 1);
+    });
+
+    function inclusiveDescendingRange(n: number, limit = 0) {
+      const range: number[] = [];
+      while (n >= limit) range.push(n--);
+      return range;
+    }
+
+    assert.strictEqual(sumFirst(10), 55);
+    assert.deepStrictEqual(ns, inclusiveDescendingRange(10));
+
+    sumFirst.forget(6);
+    assert.strictEqual(sumFirst(4), 10);
+    assert.deepStrictEqual(ns, inclusiveDescendingRange(10));
+
+    assert.strictEqual(sumFirst(11), 66);
+    assert.deepStrictEqual(ns, [
+      ...inclusiveDescendingRange(10),
+      ...inclusiveDescendingRange(11, 6),
+    ]);
+
+    sumFirst.forget(3);
+    assert.strictEqual(sumFirst(7), 28);
+    assert.deepStrictEqual(ns, [
+      ...inclusiveDescendingRange(10),
+      ...inclusiveDescendingRange(11, 6),
+      ...inclusiveDescendingRange(7, 3),
+    ]);
+  });
 });

--- a/src/tests/api.ts
+++ b/src/tests/api.ts
@@ -596,7 +596,7 @@ describe("optimism", function () {
     assert.strictEqual(sumFirst(10), 55);
     assert.deepStrictEqual(ns, inclusiveDescendingRange(10));
 
-    sumFirst.forget(6);
+    assert.strictEqual(sumFirst.forget(6), true);
     assert.strictEqual(sumFirst(4), 10);
     assert.deepStrictEqual(ns, inclusiveDescendingRange(10));
 
@@ -606,12 +606,17 @@ describe("optimism", function () {
       ...inclusiveDescendingRange(11, 6),
     ]);
 
-    sumFirst.forget(3);
+    assert.strictEqual(sumFirst.forget(3), true);
     assert.strictEqual(sumFirst(7), 28);
     assert.deepStrictEqual(ns, [
       ...inclusiveDescendingRange(10),
       ...inclusiveDescendingRange(11, 6),
       ...inclusiveDescendingRange(7, 3),
     ]);
+
+    assert.strictEqual(sumFirst.forget(123), false);
+    assert.strictEqual(sumFirst.forget(-1), false);
+    assert.strictEqual(sumFirst.forget("7" as any), false);
+    assert.strictEqual((sumFirst.forget as any)(6, 4), false);
   });
 });


### PR DESCRIPTION
This method takes the same arguments as `optimistic.dirty` and `optimistic.peek` (`TKeyArgs`, as opposed to the full `TArgs` that the `optimistic` function itself takes). This distinction means you can remove entries as long as you have `TKeyArgs`, even if you don't have `TArgs`.

Like `Map.prototype.delete` and friends, `optimistic.forget` returns a boolean to indicate whether an entry was deleted.

This new API should enable a straightforward solution for https://github.com/apollographql/apollo-client/issues/7149 and https://github.com/apollographql/apollo-client/issues/7086.