### PR TITLE
Avoid storing entry.args by passing args to Entry#recompute instead.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,18 +100,15 @@ export function wrap<
       return originalFunction.apply(null, arguments as any);
     }
 
-    const args = Array.prototype.slice.call(arguments) as TArgs;
-
-    let entry = cache.get(key);
-    if (entry) {
-      entry.args = args;
-    } else {
-      entry = new Entry<TArgs, TResult>(originalFunction, args);
-      cache.set(key, entry);
+    let entry = cache.get(key)!;
+    if (!entry) {
+      cache.set(key, entry = new Entry(originalFunction));
       entry.subscribe = options.subscribe;
     }
 
-    const value = entry.recompute();
+    const value = entry.recompute(
+      Array.prototype.slice.call(arguments) as TArgs,
+    );
 
     // Move this entry to the front of the least-recently used queue,
     // since we just finished computing its value.


### PR DESCRIPTION
Pretty much any kind of memoization library will create new opportunities for memory leaks, and Optimism is a memoization library.

However, as a general rule, such libraries can reduce the frequency and/or impact of memory leaks by retaining references to fewer objects internally. In some happy cases, this reduction involves eliminating long-lived references when the same data can be provided at the right times simply by passing arguments to functions.

For example, retaining a reference to the `entry.args` array made it easier in theory to recompute any `Entry` at any time. In practice, all the code that consumes `entry.args` is called as part of `Entry#recompute`, an internal method that is only ever called from optimistic wrapper functions, which always have convenient access to the latest arguments that were passed to the wrapped function. This consumption pattern means we can get away with removing the `entry.args` member from the `Entry` class entirely, and instead call `entry.recompute(args)`, which then passes those arguments down through the tree of internal helper functions that need them. Best of all, TypeScript helps check the consistency of all these changes, making this a relatively low-risk refactoring.

This refactoring not only eliminates a potential vector for memory leaks (by retaining fewer objects per `Entry`) and simplifies the `Entry` implementation (somewhat, IMO), but also noticeably speeds up two of our performance stress tests:
```
performance [before this commit]
  ✓ should be able to tolerate lots of Entry objects (1269ms)
  ✓ should be able to tolerate lots of deps (140ms)

performance [with this commit]
  ✓ should be able to tolerate lots of Entry objects (964ms)
  ✓ should be able to tolerate lots of deps (122ms)
```
That's a 24% and a 13% improvement, respectively, presumably due to reduced GC pressure (though I haven't verified that hypothesis). Pretty good for a change that wasn't intended to be a performance optimization!