### PR TITLE
Use WeakMap and FinalizationRegistry when available.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true,
-    "lib": ["es2015"],
+    "lib": ["esnext"],
     "types": ["node", "mocha"],
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Although [`WeakRef` and `FinalizationRegistry`](https://github.com/tc39/proposal-weakrefs) are not yet supported by all browsers, I was pleasantly surprised to learn that [more than 68% of browsers](https://caniuse.com/mdn-javascript_builtins_finalizationregistry) already have support for these new APIs.

Using a `FinalizationRegistry` is appealing for this library, because it allows deleting keys from the internal LRU cache when they become unreachable, which makes sense because an unreachable key can never be looked up in the cache again. Without this functionality, a naive LRU cache will keep keys alive that could otherwise be garbage collected.

This PR uses a `FinalizationRegistry` when possible, but also allows the behavior to be configured with the `useWeakKeys` option for the `wrap` function, since the additional overhead of the registration and cleanup has a noticeable performance cost (the performance stress test run by `npm test` now takes ~1325ms instead of ~950ms, on my machine).