### PR TITLE
Skip turning arguments into array if options.keyArgs not provided.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,11 +92,15 @@ export function wrap<
     entry => entry.dispose(),
   );
 
-  const keyArgs = options.keyArgs || ((...args: TArgs): TKeyArgs => args as any);
+  const keyArgs = options.keyArgs;
   const makeCacheKey = options.makeCacheKey || defaultMakeCacheKey;
 
   function optimistic(): TResult {
-    const key = makeCacheKey.apply(null, keyArgs.apply(null, arguments as any));
+    const key = makeCacheKey.apply(
+      null,
+      keyArgs ? keyArgs.apply(null, arguments as any) : arguments as any
+    );
+
     if (key === void 0) {
       return originalFunction.apply(null, arguments as any);
     }


### PR DESCRIPTION
While debugging without source maps, I noticed that the default `keyArgs` function (which is used any time `options.keyArgs` is not provided, which is _most_ of the time) was relatively costly, because it had to convert its `arguments` into a proper `Array`, thanks to TypeScript's compilation of `...args` syntax.

Since this code runs every time we access the cache, even when the cache is warm, it's important for it to be as fast as possible. Luckily, instead of using a default `keyArgs` function, we can skip calling `keyArgs` altogether, which is almost certainly faster.