### PR TITLE
add getKey and forgetKey API (#188)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,10 @@ export type OptimisticWrapperFunction<
   peek: (...args: TKeyArgs) => TResult | undefined;
   // Remove the entry from the cache, dirtying any parent entries.
   forget: (...args: TKeyArgs) => boolean;
+  // Returns the key for the supplied arguments
+  getKey: (...args: TArgs) => any;
+  // Removes the entry from the cache using its key, dirtying any parent entries
+  forgetKey: (key: any) => boolean;
 };
 
 export type OptimisticWrapOptions<
@@ -155,6 +159,18 @@ export function wrap<
 
   optimistic.forget = function () {
     const key = makeCacheKey.apply(null, arguments as any);
+    return key !== void 0 && cache.delete(key);
+  };
+
+  optimistic.getKey = function () {
+    const key = makeCacheKey.apply(
+        null,
+        keyArgs ? keyArgs.apply(null, arguments as any) : arguments as any
+      );
+    return key;
+  };
+
+  optimistic.forgetKey = function (key: any) {
     return key !== void 0 && cache.delete(key);
   };
 

--- a/src/tests/api.ts
+++ b/src/tests/api.ts
@@ -619,4 +619,46 @@ describe("optimism", function () {
     assert.strictEqual(sumFirst.forget("7" as any), false);
     assert.strictEqual((sumFirst.forget as any)(6, 4), false);
   });
+
+  it("allows forgetting entries by key", function () {
+    const ns: number[] = [];
+    const sumFirst = wrap(function (n: number): number {
+      ns.push(n);
+      return n < 1 ? 0 : n + sumFirst(n - 1);
+    }, {
+        makeCacheKey: function (x: number) {
+          return x * 2;
+        }
+    });
+
+    assert.strictEqual(sumFirst(10), 55);
+
+    /*
+     * Verify:
+     * 1- Calling forgetKey will remove the entry.
+     * 2- Calling forgetKey again will return false.
+     * 3- Callling forget on the same entry will return false.
+     */
+    assert.strictEqual(sumFirst.forgetKey(6 * 2), true);
+    assert.strictEqual(sumFirst.forgetKey(6 * 2), false);
+    assert.strictEqual(sumFirst.forget(6), false);
+
+    /*
+     * Verify:
+     * 1- Calling forget will remove the entry.
+     * 2- Calling forget again will return false.
+     * 3- Callling forgetKey on the same entry will return false.
+     */
+    assert.strictEqual(sumFirst.forget(7), true);
+    assert.strictEqual(sumFirst.forget(7), false);
+    assert.strictEqual(sumFirst.forgetKey(7 * 2), false);
+
+    /*
+     * Verify you can query an entry key.
+     */
+    assert.strictEqual(sumFirst.getKey(9), 18);
+    assert.strictEqual(sumFirst.forgetKey(sumFirst.getKey(9)), true);
+    assert.strictEqual(sumFirst.forgetKey(sumFirst.getKey(9)), false);
+    assert.strictEqual(sumFirst.forget(9), false);
+  });
 });


### PR DESCRIPTION
Per the conversation in https://github.com/apollographql/apollo-feature-requests/issues/289, add `getKey` & `forgetKey` API's to `OptimisticWrapperFunction`.

The motive here is to keep track of the cached entries without having to memoize the arguments and duplicate the logic for weakly tracking them. This will enable the creators of `OptimisticWrapperFunction` to use the _true_ keys for removing entries via the `forgetKey` API.