### PR TITLE
Allow dep.dirty to invoke Entry methods other than setDirty

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -104,8 +104,7 @@ export class Entry<TArgs extends any[], TValue> {
   }
 
   public dispose() {
-    forgetChildren(this);
-    maybeUnsubscribe(this);
+    this.setDirty();
 
     // Because this entry has been kicked out of the cache (in index.js),
     // we've lost the ability to find out if/when this entry becomes dirty,
@@ -122,6 +121,13 @@ export class Entry<TArgs extends any[], TValue> {
       parent.setDirty();
       forgetChild(parent, this);
     });
+  }
+
+  public forget() {
+    // The code that creates Entry objects in index.ts will replace this method
+    // with one that actually removes the Entry from the cache, which will also
+    // trigger the entry.dispose method.
+    this.dispose();
   }
 
   private deps: Set<Dep<any>> | null = null;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,7 @@
+export const {
+  hasOwnProperty,
+} = Object.prototype;
+
 export type Unsubscribable = {
   unsubscribe?: void | (() => any);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,9 @@ export function wrap<
     if (!entry) {
       cache.set(key, entry = new Entry(originalFunction));
       entry.subscribe = options.subscribe;
+      // Give the Entry the ability to trigger cache.delete(key), even though
+      // the Entry itself does not know about key or cache.
+      entry.forget = () => cache.delete(key);
     }
 
     const value = entry.recompute(


### PR DESCRIPTION
This improvement to the `dep.dirty` API allows invalidating the `Entry` graph in more flexible/drastic ways.

Specifically, a cached function can call `someDep(key)` during its initial computation to register an atomic dependency (as before), and then later calling `someDep.dirty(key, "forget")` will cause the parent `Entry` to be completely removed from the computation graph. This removal is more drastic than just dirtying the `Entry` with `entry.setDirty()` (which is the default/current behavior of `someDep.dirty(key)`) because it release all memory associated with the `Entry` and requires it to be recreated if it's ever needed again.

@SofianHn I think this functionality is most of what's needed to implement the second half of your original PR https://github.com/apollographql/apollo-client/pull/8107. Specifically, `this.evictDep(dataId)` would be called in the wrapper functions for `executeSelectionSet` and `executeSubSelectedArray`, and then `this.evictDep.dirty(dataId, "forget")` could be called whenever that `dataId` gets evicted, so you don't have to track those dependencies manually.