### PR TITLE
Support `options.normalizeResult` callback in `wrap(fn, options)` to allow reconciling newly computed results with previous results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.2.5",
+        "@wry/equality": "^0.5.7",
         "mocha": "^10.2.0",
         "rimraf": "^5.0.0",
         "rollup": "^3.20.0",
@@ -51,6 +52,18 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
       "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1218,6 +1231,15 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
       "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.2.5",
+    "@wry/equality": "^0.5.7",
     "mocha": "^10.2.0",
     "rimraf": "^5.0.0",
     "rollup": "^3.20.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ const globals = {
   tslib: "tslib",
   assert: "assert",
   crypto: "crypto",
+  "@wry/equality": "wryEquality",
   "@wry/context": "wryContext",
   "@wry/trie": "wryTrie",
   "@wry/caches": "wryCaches",

--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -1,0 +1,14 @@
+export function permutations<T>(array: T[], start = 0): T[][] {
+  if (start === array.length) return [[]];
+  const item = array[start];
+  const results: T[][] = [];
+  permutations<T>(array, start + 1).forEach(perm => {
+    perm.forEach((_, i) => {
+      const copy = perm.slice(0);
+      copy.splice(i, 0, item);
+      results.push(copy);
+    });
+    results.push(perm.concat(item));
+  });
+  return results;
+}


### PR DESCRIPTION
Sometimes a function cached with `optimism` will be spuriously dirtied (directly or indirectly) in a way that triggers recomputation the next time the function is called. The newly computed result may be logically different from the previous result, of course, but if the two results are equivalent (or share equivalent subparts), the developer may wish to keep using (parts of) the previous result.

To take advantage of this system for reconciling cached results, pass an `options.normalizeResult` callback in the options for the `wrap` function:
```ts
// Use any deep equality test you like:
import { equal } from "@wry/equality"

const range = wrap((n: number): number[] => {
  return n > 0 ? range(n - 1).concat(n - 1) : [];
}, {
  normalizeResult(newer: number[], older: number[]) {
    return equal(newer, older) ? older : newer;
  },
});
```
Normally, this function would always return the `newer` array, but using `normalizeResult` allows the `optimism` system to continue using `older` in cases where `equal(newer, older)`, which helps limit referential diversity of `range` arrays over time.

Since this `normalizeResult` system works within `optimism`, at each level of the dependency graph, it should be able to provide referential stability benefits similar to those promised by cache result canonization (https://github.com/apollographql/apollo-client/pull/7439), without using nearly as much memory.