### PR TITLE
Upgrade @wry/context to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
-        "@wry/context": "^0.6.0",
+        "@wry/context": "^0.7.0",
         "@wry/trie": "^0.3.0"
       },
       "devDependencies": {
@@ -59,9 +59,9 @@
       "dev": true
     },
     "node_modules/@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
+      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1527,9 +1527,9 @@
       "dev": true
     },
     "@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
+      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@wry/context": "^0.6.0",
+    "@wry/context": "^0.7.0",
     "@wry/trie": "^0.3.0"
   }
 }


### PR DESCRIPTION
Apollo Client depends on `@wry/context` `^0.7.0` and on `optimism` `^0.16.1` which pulled in 2 versions of `@wry/context` which seems unnecessary. Bumping `@wry/context` here resolves this.