### PR TITLE
Move `tslib` from `devDependencies` to `dependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/trie": "^0.3.0",
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.0.0",
@@ -19,7 +20,6 @@
         "rimraf": "^3.0.2",
         "rollup": "^3.20.0",
         "source-map-support": "^0.5.19",
-        "tslib": "^2.5.0",
         "typescript": "^5.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "rimraf": "^3.0.2",
     "rollup": "^3.20.0",
     "source-map-support": "^0.5.19",
-    "tslib": "^2.5.0",
     "typescript": "^5.0.2"
   },
   "dependencies": {
     "@wry/context": "^0.7.0",
-    "@wry/trie": "^0.3.0"
+    "@wry/trie": "^0.3.0",
+    "tslib": "^2.3.0"
   }
 }


### PR DESCRIPTION
This seems to be required by our use of `"importHelpers": true` in [`tsconfig.json`](https://github.com/benjamn/optimism/blob/cd90c68ecf4a6ee4551e2d24ebb0e041b8768091/tsconfig.json#L10), though I don't think the `optimism` implementation currently imports any `tslib` helpers outside of tests.