### PR TITLE
Support `nonReactive(() => ...)` to avoid encouraging the sledgehammer `noContext`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,11 @@
 import { Slot } from "@wry/context";
 import { AnyEntry } from "./entry.js";
 
-export const parentEntrySlot = new Slot<AnyEntry>();
+export const parentEntrySlot = new Slot<AnyEntry | undefined>();
+
+export function nonReactive<R>(fn: () => R): R {
+  return parentEntrySlot.withValue(void 0, fn);
+}
 
 export {
   bind as bindContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { parentEntrySlot } from "./context.js";
 export {
   bindContext,
   noContext,
+  nonReactive,
   setTimeout,
   asyncFromGen,
 } from "./context.js";


### PR DESCRIPTION
The drawback of `noContext` is that it censors _all_ contextual `Slot` values from the inner function's context, when the only `Slot` used by `optimism` is the `parentEntrySlot`.

The new `nonReactive` function is like `noContext`, but it censors only `parentEntrySlot`, to avoid registering dependencies while executing certain code known/suspected to contain functions `wrap`ped by `optimism`.