### PR TITLE
Revert "Cleanup `depsByKey` when all dependant entries are disposed" (PR #498)

### DIFF
--- a/src/dep.ts
+++ b/src/dep.ts
@@ -17,7 +17,6 @@ export type OptimisticDependencyFunction<TKey> =
 
 export type Dep<TKey> = Set<AnyEntry> & {
   subscribe: OptimisticWrapOptions<[TKey]>["subscribe"];
-  cleanup: () => void,
 } & Unsubscribable;
 
 export function dep<TKey>(options?: {
@@ -29,14 +28,9 @@ export function dep<TKey>(options?: {
   function depend(key: TKey) {
     const parent = parentEntrySlot.getValue();
     if (parent) {
-      let dep = depsByKey.get(key) as Dep<TKey>;
+      let dep = depsByKey.get(key);
       if (!dep) {
         depsByKey.set(key, dep = new Set as Dep<TKey>);
-        dep.cleanup = () => {
-          if (dep.size === 0) {
-            depsByKey.delete(key);
-          }
-        };
       }
       parent.dependOn(dep);
       if (typeof subscribe === "function") {


### PR DESCRIPTION
This reverts commit 884d2b67125c106ec6c7ea712b51fc5039f246a2, following advice from @vladar in https://github.com/benjamn/optimism/pull/498#issuecomment-1488285575. I don't have an immediate theory about what could have changed here, but if anyone has ideas, feel free to leave a comment below.