### PR TITLE
Cleanup depsByKey when all dependant entries are disposed

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -147,7 +147,10 @@ export class Entry<TArgs extends any[], TValue> {
 
   public forgetDeps() {
     if (this.deps) {
-      toArray(this.deps).forEach(dep => dep.delete(this));
+      toArray(this.deps).forEach(dep => {
+        dep.delete(this);
+        dep.cleanup();
+      });
       this.deps.clear();
       emptySetPool.push(this.deps);
       this.deps = null;

--- a/src/tests/deps.ts
+++ b/src/tests/deps.ts
@@ -180,4 +180,176 @@ describe("OptimisticDependencyFunction<TKey>", () => {
     assert.strictEqual(parent("blep"), 3);
     check({ subscribe: 4, unsubscribe: 2, parent: 4 });
   });
+
+  describe("cleanup", () => {
+    it("cleans up correctly on LRU eviction", () => {
+      let subscribeFooCount = 0;
+      let unsubscribeFooCount = 0;
+      let parentCallCount = 0;
+
+      const d = dep({
+        subscribe(key: string) {
+          if (key !== "foo") return;
+
+          ++subscribeFooCount;
+          return () => {
+            ++unsubscribeFooCount;
+          };
+        },
+      });
+
+      const lruCacheMaxSize = 1;
+
+      const parent = wrap((key: string) => {
+        d(key);
+        return ++parentCallCount;
+      }, { max: lruCacheMaxSize });
+
+      parent("foo");
+      parent("foo");
+      parent("bar"); // trigger LRU eviction of "foo" (expecting unsubscribe here)
+
+      assert.strictEqual(subscribeFooCount, 1);
+      assert.strictEqual(unsubscribeFooCount, 1);
+      assert.strictEqual(d.keyCount(), 1);
+    });
+
+    it("cleans up after being marked as dirty", () => {
+      let subscribeCallCount = 0;
+      let unsubscribeCallCount = 0;
+      let parent1CallCount = 0;
+      let parent2CallCount = 0;
+
+      const parent1 = wrap((key: string) => {
+        d(key);
+        return parent1CallCount++;
+      });
+
+      const parent2 = wrap((key: string) => {
+        d(key);
+        return parent2CallCount++;
+      });
+
+      const d = dep({
+        subscribe(_: string) {
+          ++subscribeCallCount
+          return () => {
+            ++unsubscribeCallCount;
+          };
+        },
+      });
+
+      parent1("foo");
+      parent2("foo");
+      assert.strictEqual(subscribeCallCount, 2);
+      assert.strictEqual(unsubscribeCallCount, 1);
+      assert.strictEqual(d.keyCount(), 1);
+
+      d.dirty("foo");
+      assert.strictEqual(subscribeCallCount, 2);
+      assert.strictEqual(unsubscribeCallCount, 2);
+      assert.strictEqual(d.keyCount(), 0);
+
+      parent1("foo");
+      assert.strictEqual(subscribeCallCount, 3);
+      assert.strictEqual(unsubscribeCallCount, 2);
+      assert.strictEqual(d.keyCount(), 1);
+
+      parent2("foo");
+      assert.strictEqual(subscribeCallCount, 4);
+      assert.strictEqual(unsubscribeCallCount, 3);
+      assert.strictEqual(d.keyCount(), 1);
+
+      d.dirty("foo");
+      assert.strictEqual(subscribeCallCount, 4);
+      assert.strictEqual(unsubscribeCallCount, 4);
+      assert.strictEqual(d.keyCount(), 0);
+    });
+
+    it("cleans up unused keys on recompute", () => {
+      let subscribeFirstCount = 0;
+      let unsubscribeFirstCount = 0;
+      let firstCall = true;
+
+      const d = dep({
+        subscribe(key: string) {
+          if (key !== "first") return;
+
+          ++subscribeFirstCount
+          return () => {
+            ++unsubscribeFirstCount;
+          };
+        },
+      });
+
+      const parent = wrap((key: string) => {
+        if (firstCall) {
+          d("first");
+          firstCall = false;
+        }
+        d(key);
+        return key;
+      });
+
+      parent("foo");
+      assert.strictEqual(subscribeFirstCount, 1);
+      assert.strictEqual(unsubscribeFirstCount, 0);
+      assert.strictEqual(d.keyCount(), 2); // "first", "foo"
+
+      d.dirty("foo");
+      assert.strictEqual(subscribeFirstCount, 1);
+      assert.strictEqual(unsubscribeFirstCount, 0);
+      assert.strictEqual(d.keyCount(), 1); // "first"
+
+      parent("foo");
+      assert.strictEqual(subscribeFirstCount, 1);
+      assert.strictEqual(unsubscribeFirstCount, 1);
+      assert.strictEqual(d.keyCount(), 1); // "foo"
+
+      d.dirty("foo")
+      assert.strictEqual(subscribeFirstCount, 1);
+      assert.strictEqual(unsubscribeFirstCount, 1);
+      assert.strictEqual(d.keyCount(), 0);
+    });
+
+    it("cleans up on LRU eviction after being marked as dirty", () => {
+      type Keys = "foo" | "bar";
+      const subscribeCalls = { foo: 0, bar: 0 };
+      const unsubscribeCalls = { foo: 0, bar: 0 };
+      const calls = { foo: 0, bar: 0 };
+
+      const lruCacheMaxSize = 1;
+
+      const parent1 = wrap((key: Keys) => {
+        d(key);
+        return calls[key]++;
+      }, { max: lruCacheMaxSize });
+
+      const parent2 = wrap((key: Keys) => {
+        d(key);
+        return calls[key]++;
+      });
+
+      const d = dep({
+        subscribe(key: Keys) {
+          subscribeCalls[key]++
+          return () => {
+            unsubscribeCalls[key]++;
+          };
+        },
+      });
+
+      parent1("foo");
+      d.dirty("foo");
+      parent2("foo");
+      assert.strictEqual(subscribeCalls.foo, 2);
+      assert.strictEqual(unsubscribeCalls.foo, 1);
+      assert.strictEqual(d.keyCount(), 1);
+
+      parent1("bar"); // trigger LRU eviction of "foo" from parent1
+      assert.strictEqual(subscribeCalls.foo, 2);
+      assert.strictEqual(unsubscribeCalls.foo, 1); // parent2 still depends on "foo"
+      assert.strictEqual(d.keyCount(), 2); // foo (for parent2), bar (for parent1)
+    });
+  })
 });


### PR DESCRIPTION
> This is a follow up for #498 that was reverted in #518 due to the discovered bug.

Clear keys in `depsByKey` when all previously tracked entries are disposed. This time, came up with multiple tests indicating a leak, and also a test for the edge-case, causing failures with the original PR.

Fixes #497