### PR TITLE
Rename `toArray` to `arrayFromSet` and simplify `export` syntax

### DIFF
--- a/src/dep.ts
+++ b/src/dep.ts
@@ -1,7 +1,12 @@
 import { AnyEntry } from "./entry.js";
 import { OptimisticWrapOptions } from "./index.js";
 import { parentEntrySlot } from "./context.js";
-import { hasOwnProperty, Unsubscribable, maybeUnsubscribe, toArray } from "./helpers.js";
+import {
+  hasOwnProperty,
+  Unsubscribable,
+  maybeUnsubscribe,
+  arrayFromSet,
+ } from "./helpers.js";
 
 type EntryMethodName = keyof typeof EntryMethods;
 const EntryMethods = {
@@ -50,10 +55,10 @@ export function dep<TKey>(options?: {
         entryMethodName &&
         hasOwnProperty.call(EntryMethods, entryMethodName)
       ) ? entryMethodName : "setDirty";
-      // We have to use toArray(dep).forEach instead of dep.forEach, because
+      // We have to use setToArray(dep).forEach instead of dep.forEach, because
       // modifying a Set while iterating over it can cause elements in the Set
       // to be removed from the Set before they've been iterated over.
-      toArray(dep).forEach(entry => entry[m]());
+      arrayFromSet(dep).forEach(entry => entry[m]());
       depsByKey.delete(key);
       maybeUnsubscribe(dep);
     }

--- a/src/dep.ts
+++ b/src/dep.ts
@@ -55,9 +55,9 @@ export function dep<TKey>(options?: {
         entryMethodName &&
         hasOwnProperty.call(EntryMethods, entryMethodName)
       ) ? entryMethodName : "setDirty";
-      // We have to use setToArray(dep).forEach instead of dep.forEach, because
-      // modifying a Set while iterating over it can cause elements in the Set
-      // to be removed from the Set before they've been iterated over.
+      // We have to use arrayFromSet(dep).forEach instead of dep.forEach,
+      // because modifying a Set while iterating over it can cause elements in
+      // the Set to be removed from the Set before they've been iterated over.
       arrayFromSet(dep).forEach(entry => entry[m]());
       depsByKey.delete(key);
       maybeUnsubscribe(dep);

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,7 +1,7 @@
 import { parentEntrySlot } from "./context.js";
 import { OptimisticWrapOptions } from "./index.js";
 import { Dep } from "./dep.js";
-import { maybeUnsubscribe, toArray, Unsubscribable } from "./helpers.js";
+import { maybeUnsubscribe, arrayFromSet, Unsubscribable } from "./helpers.js";
 
 const emptySetPool: Set<any>[] = [];
 const POOL_TARGET_SIZE = 100;
@@ -147,7 +147,7 @@ export class Entry<TArgs extends any[], TValue> {
 
   public forgetDeps() {
     if (this.deps) {
-      toArray(this.deps).forEach(dep => dep.delete(this));
+      arrayFromSet(this.deps).forEach(dep => dep.delete(this));
       this.deps.clear();
       emptySetPool.push(this.deps);
       this.deps = null;
@@ -234,7 +234,7 @@ function eachParent(
 ) {
   const parentCount = child.parents.size;
   if (parentCount) {
-    const parents = toArray(child.parents);
+    const parents = arrayFromSet(child.parents);
     for (let i = 0; i < parentCount; ++i) {
       callback(parents[i], child);
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,18 +2,13 @@ export const {
   hasOwnProperty,
 } = Object.prototype;
 
-export const {
-  // This Array.from polyfill is restricted to working with Set<any> for now,
-  // but we can improve the polyfill and add other input types, as needed. Note
-  // that this fallback implementation will only be used if the host environment
-  // does not support a native Array.from function. In most modern JS runtimes,
-  // the toArray function exported here will be === Array.from.
-  from: toArray = (collection: Set<any>) => {
+export const arrayFromSet: <T>(set: Set<T>) => T[] =
+  Array.from ||
+  function (set) {
     const array: any[] = [];
-    collection.forEach(item => array.push(item));
+    set.forEach(item => array.push(item));
     return array;
-  },
-} = Array;
+  };
 
 export type Unsubscribable = {
   unsubscribe?: void | (() => any);


### PR DESCRIPTION
As @alessbell has reported in https://github.com/codesandbox/sandpack/issues/940, it appears [Sandpack](https://sandpack.codesandbox.io/) may have a transpiler bug when compiling the following code:
```ts
export const {
  from: toArray = (collection: Set<any>) => {
    const array: any[] = [];
    collection.forEach(item => array.push(item));
    return array;
  },
} = Array;
```
It's understandable the combination of `export`, destructuring, renaming `from: toArray`, and a default expression would be unusual enough to have escaped testing, but this works with other transpilers, and is valid TypeScript (and should compile to equivalent valid JS).

What happens, specifically, is that `exports.toArray` never gets assigned like `exports.hasOwnProperty` and `exports.maybeUnsubscribe`, presumably because `toArray` is not detected as an exported identifier.

Fortunately, there's another way of writing this code that should be less challenging to transpile:
```ts
export const arrayFromSet: <T>(set: Set<T>) => T[] =
  Array.from ||
  function (set) {
    const array: any[] = [];
    set.forEach(item => array.push(item));
    return array;
  };
```

I took this opportunity to rename the helper function from `toArray` to `arrayFromSet`, reflecting the fact that we use this function only for converting sets to arrays, which allows us to keep the fallback function simple (for use when `Array.from` is not available).