### PR TITLE
Add configurable `WeakCache` implementation based on `FinalizationRegistry`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tsc:es5": "tsc -p tsconfig.es5.json",
     "clean": "rimraf lib",
     "prepare": "npm run build",
-    "mocha": "mocha --require source-map-support/register --reporter spec --full-trace",
+    "mocha": "mocha --require source-map-support/register --reporter spec --full-trace -n expose-gc",
     "test:cjs": "npm run mocha -- lib/tests/bundle.cjs",
     "test:esm": "npm run mocha -- lib/tests/bundle.js",
     "test": "npm run test:esm && npm run test:cjs"

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -26,6 +26,10 @@ export class Cache<K = any, V = any> {
     return node && node.value;
   }
 
+  public get size() {
+    return this.map.size;
+  }
+
   private getNode(key: K): Node<K, V> | undefined {
     const node = this.map.get(key);
 

--- a/src/tests/api.ts
+++ b/src/tests/api.ts
@@ -7,6 +7,8 @@ import {
 } from "../index";
 import { wrapYieldingFiberMethods } from '@wry/context';
 import { dep } from "../dep";
+import { WeakCache } from "../weakCache";
+import { Cache } from "../cache";
 
 type NumThunk = OptimisticWrapperFunction<[], number>;
 
@@ -14,6 +16,36 @@ describe("optimism", function () {
   it("sanity", function () {
     assert.strictEqual(typeof wrap, "function");
     assert.strictEqual(typeof defaultMakeCacheKey, "function");
+  });
+
+  it("can manually set the `Cache` to `WeakCache`", async () => {
+    let cache: WeakCache
+    wrap((obj: { value: string }) => obj.value, {
+      Cache: (class extends WeakCache {
+        constructor(...args: ConstructorParameters<typeof WeakCache>) {
+          super(...args)
+          cache = this
+        } 
+      }) as typeof WeakCache
+    });
+    // can't access the cache otherwise, so we can only test if the `Cache`
+    // argument constructor was called, not if it's actually used internally
+    assert.ok(cache! instanceof WeakCache);
+  });
+
+  it("can manually set the `Cache` to `Cache`", () => {
+    let cache: Cache
+    wrap((obj: { value: string }) => obj.value, {
+      Cache: (class extends Cache {
+        constructor(...args: ConstructorParameters<typeof Cache>) {
+          super(...args)
+          cache = this
+        } 
+      }) as typeof Cache
+    });
+    // can't access the cache otherwise, so we can only test if the `Cache`
+    // argument constructor was called, not if it's actually used internally
+    assert.ok(cache! instanceof Cache);
   });
 
   it("works with single functions", function () {

--- a/src/tests/main.ts
+++ b/src/tests/main.ts
@@ -5,3 +5,4 @@ import "./key-trie";
 import "./context";
 import "./exceptions";
 import "./performance";
+import "./weakCache";

--- a/src/tests/weakCache.ts
+++ b/src/tests/weakCache.ts
@@ -1,0 +1,117 @@
+import * as assert from "assert";
+import { WeakCache } from "../weakCache";
+
+describe("weak least-recently-used cache", function () {
+  it("can hold lots of elements", function () {
+    const cache = new WeakCache();
+    const count = 1000000;
+    const keys = [];
+
+    for (let i = 0; i < count; ++i) {
+      const key = {};
+      cache.set(key, String(i));
+      keys[i] = key;
+    }
+
+    cache.clean();
+
+    assert.strictEqual(cache.size, count);
+    assert.ok(cache.has(keys[0]));
+    assert.ok(cache.has(keys[count - 1]));
+    assert.strictEqual(cache.get(keys[43]), "43");
+  });
+
+  it("evicts excess old elements", function () {
+    const max = 10;
+    const evicted = [];
+    const cache = new WeakCache(max, (value, key) => {
+      assert.strictEqual(key.valueOf(), value.valueOf());
+      evicted.push(key);
+    });
+
+    const count = 100;
+    const keys = [];
+    for (let i = 0; i < count; ++i) {
+      const key = new String(i);
+      cache.set(key, String(i));
+      keys[i] = key;
+    }
+
+    cache.clean();
+
+    assert.strictEqual((cache as any).size, max);
+    assert.strictEqual(evicted.length, count - max);
+
+    for (let i = count - max; i < count; ++i) {
+      assert.ok(cache.has(keys[i]));
+    }
+  });
+
+  it("can cope with small max values", function () {
+    const cache = new WeakCache(2);
+    const keys = Array(10)
+      .fill(null)
+      .map((_, i) => new Number(i));
+
+    function check(...sequence: number[]) {
+      cache.clean();
+
+      let entry = (cache as any).newest;
+      const forwards = [];
+      while (entry) {
+        forwards.push(entry.keyRef.deref());
+        entry = entry.older;
+      }
+      assert.deepEqual(forwards.map(Number), sequence);
+
+      const backwards = [];
+      entry = (cache as any).oldest;
+      while (entry) {
+        backwards.push(entry.keyRef.deref());
+        entry = entry.newer;
+      }
+      backwards.reverse();
+      assert.deepEqual(backwards.map(Number), sequence);
+
+      sequence.forEach(function (n) {
+        assert.strictEqual((cache as any).map.get(keys[n]).value, n + 1);
+      });
+
+      if (sequence.length > 0) {
+        assert.strictEqual((cache as any).newest.keyRef.deref().valueOf(), sequence[0]);
+        assert.strictEqual(
+          (cache as any).oldest.keyRef.deref().valueOf(),
+          sequence[sequence.length - 1]
+        );
+      }
+    }
+
+    cache.set(keys[1], 2);
+    check(1);
+
+    cache.set(keys[2], 3);
+    check(2, 1);
+
+    cache.set(keys[3], 4);
+    check(3, 2);
+
+    cache.get(keys[2]);
+    check(2, 3);
+
+    cache.set(keys[4], 5);
+    check(4, 2);
+
+    assert.strictEqual(cache.has(keys[1]), false);
+    assert.strictEqual(cache.get(keys[2]), 3);
+    assert.strictEqual(cache.has(keys[3]), false);
+    assert.strictEqual(cache.get(keys[4]), 5);
+
+    cache.delete(keys[2]);
+    check(4);
+    cache.delete(keys[4]);
+    check();
+
+    assert.strictEqual((cache as any).newest, null);
+    assert.strictEqual((cache as any).oldest, null);
+  });
+});

--- a/src/weakCache.ts
+++ b/src/weakCache.ts
@@ -1,0 +1,115 @@
+interface Node<K, V> {
+  key: K;
+  value: V;
+  newer: Node<K, V> | null;
+  older: Node<K, V> | null;
+}
+
+function defaultDispose() {}
+
+export class Cache<K = any, V = any> {
+  private map = new Map<K, Node<K, V>>();
+  private newest: Node<K, V> | null = null;
+  private oldest: Node<K, V> | null = null;
+
+  constructor(
+    private max = Infinity,
+    public dispose: (value: V, key: K) => void = defaultDispose,
+  ) {}
+
+  public has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  public get(key: K): V | undefined {
+    const node = this.getNode(key);
+    return node && node.value;
+  }
+
+  private getNode(key: K): Node<K, V> | undefined {
+    const node = this.map.get(key);
+
+    if (node && node !== this.newest) {
+      const { older, newer } = node;
+
+      if (newer) {
+        newer.older = older;
+      }
+
+      if (older) {
+        older.newer = newer;
+      }
+
+      node.older = this.newest;
+      node.older!.newer = node;
+
+      node.newer = null;
+      this.newest = node;
+
+      if (node === this.oldest) {
+        this.oldest = newer;
+      }
+    }
+
+    return node;
+  }
+
+  public set(key: K, value: V): V {
+    let node = this.getNode(key);
+    if (node) {
+      return node.value = value;
+    }
+
+    node = {
+      key,
+      value,
+      newer: null,
+      older: this.newest
+    };
+
+    if (this.newest) {
+      this.newest.newer = node;
+    }
+
+    this.newest = node;
+    this.oldest = this.oldest || node;
+
+    this.map.set(key, node);
+
+    return node.value;
+  }
+
+  public clean() {
+    while (this.oldest && this.map.size > this.max) {
+      this.delete(this.oldest.key);
+    }
+  }
+
+  public delete(key: K): boolean {
+    const node = this.map.get(key);
+    if (node) {
+      if (node === this.newest) {
+        this.newest = node.older;
+      }
+
+      if (node === this.oldest) {
+        this.oldest = node.newer;
+      }
+
+      if (node.newer) {
+        node.newer.older = node.older;
+      }
+
+      if (node.older) {
+        node.older.newer = node.newer;
+      }
+
+      this.map.delete(key);
+      this.dispose(node.value, key);
+
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/weakCache.ts
+++ b/src/weakCache.ts
@@ -101,7 +101,7 @@ export class WeakCache<K extends object = any, V = any> {
     this.newest = node;
     this.oldest = this.oldest || node;
 
-    this.registry.register(key, node);
+    this.registry.register(key, node, node);
     this.map.set(key, node);
     this.size++;
 
@@ -133,6 +133,7 @@ export class WeakCache<K extends object = any, V = any> {
     this.size--;
     const key = node.keyRef.deref();
     this.dispose(node.value, key);
+    this.registry.unregister(node);
     if (key) this.map.delete(key);
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true,
-    "lib": ["es2015"],
+    "lib": ["es2015", "ES2021.WeakRef"],
     "types": ["node", "mocha"],
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
This would be an alternative approach to #132 - and adds a second implementation of `Cache` that only allows object keys and is based on `WeakMap`, with automatic cleanup.

I tried integrating it with the original `Cache` at first, but it 
* made the implementation hard to reason about
* changed the public api of `Cache` (there cannot be a guarantee that `dispose` is called with a `key`!)
* felt a lot less intentional - it would end up as a cache that accepted both strong and weak keys, which could invite bugs in downstream code. I prefer this option of a "deliberately weak-only" alternative implementation.

The new `WeakCache` would be incredibly useful in Apollo Client in multiple places, and could also be plugged in quite a lot of our `wrap` usages.

This implementation polyfills `WeakMap` with `Map` and `FinalizationRegistry` and `WeakRef` with dummy functions, so it will work in e.g. React Native, but it won't collect weak values.

I haven't finished tests on cleanup behaviour yet, as I wanted to wait for feedback if this is interesting at all first.

For review purposes, it can make sense to look at commit 1e26a2c0695d9ba9af488042728f5d69a724f4af independently - the first commit in this PR only copies over the existing `Cache`, so it adds a lot of clutter.