### PR TITLE
Re-export `Slot` so consumers need not import it from `@wry/context`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -7,6 +7,7 @@ export function nonReactive<R>(fn: () => R): R {
   return parentEntrySlot.withValue(void 0, fn);
 }
 
+export { Slot }
 export {
   bind as bindContext,
   noContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
   nonReactive,
   setTimeout,
   asyncFromGen,
+  Slot,
 } from "./context.js";
 
 // A lighter-weight dependency, similar to OptimisticWrapperFunction, except

--- a/src/tests/context.ts
+++ b/src/tests/context.ts
@@ -1,4 +1,3 @@
-import { Slot } from "@wry/context";
 import * as assert from "assert";
 import {
   wrap,
@@ -6,6 +5,7 @@ import {
   asyncFromGen,
   noContext,
   nonReactive,
+  Slot,
 } from '../index.js';
 
 describe("asyncFromGen", function () {


### PR DESCRIPTION
Because Apollo Client uses the `Slot` constructor directly [here](https://github.com/apollographql/apollo-client/blob/8329f07e544d1c70a0e15c6a5ccc1d563ab72f8a/src/cache/inmemory/reactiveVars.ts#L16-L18), it needs to have a direct dependency on the `@wry/context` package in addition to depending on `optimism`, which has caused dependency version mismatches leading to duplicate installs of `@wry/context`, which can cause problems with some bundlers.

Instead, when you're already using `optimism`, you might as well import the same version of `Slot` that it uses, which is what this PR enables.